### PR TITLE
DBC-NOTASK - Wrap query in quotes to treat as string.

### DIFF
--- a/ting_search_autocomplete.pages.inc
+++ b/ting_search_autocomplete.pages.inc
@@ -32,7 +32,7 @@ function ting_search_autocomplete($query) {
 
       $suggestion_query = array(
         'access_token' => $access_token,
-        'q' => $query,
+        'q' => '"' . $query . '"',
       );
 
       $options = array(


### PR DESCRIPTION
This error has been spotted:
```
sideejer@ucsj-p01:/data/www/ucsj_prod$ drush wd-show --extended --full 21968056
 ID         :  21968056
 Type       :  ting_search_autocomplete
 Message    :  Failed to fetch suggestions from https://openplatform.dbc.dk/v3/suggest?access_token=bb333ebf47b8a8d1c6f0d400ce7b8bc5c2cc9482&q=150. Code: 400. Error: Bad Request.
 Severity   :  error
 Location   :  https://biblioteket.pha.dk/ting/autocomplete/15
 Hostname   :  130.225.168.77
 Date       :  10/okt 10:56
```


https://openplatform.dbc.dk/v3/suggest?access_token=bb333ebf47b8a8d1c6f0d400ce7b8bc5c2cc9482&q=150
```
{
  statusCode: 400,
  error: "q is not of a type(s) string"
}
```


https://openplatform.dbc.dk/v3/suggest?access_token=bb333ebf47b8a8d1c6f0d400ce7b8bc5c2cc9482&q=%22150%22
```
{
  statusCode: 200,
  data: [...]
}
```
